### PR TITLE
Gradient random crash

### DIFF
--- a/src/BerconGradient.cpp
+++ b/src/BerconGradient.cpp
@@ -1108,7 +1108,10 @@ void BerconGradient::seedRandomGen(ShadeContext& sc) {
 			seed += sc.mtlNum;
 		}
 		if (p_randObj) {
-			int hand = (int)sc.Node()->GetHandle();
+			int hand = 0;
+			if (sc.Node())
+				hand = (int)sc.Node()->GetHandle();
+
 			seed += hand*(hand*hand*15731 + 789221);
 		}
 		if (p_randPar) {

--- a/src/BerconSC.h
+++ b/src/BerconSC.h
@@ -17,6 +17,8 @@ under the License.
 
 #include "max.h"
 
+#define BERCON_SHADE_CONTEXT_CLASS_ID Class_ID(0x7c0a38f1, 0x2f1a67f2)
+
 class BerconSC: public ShadeContext {
 private:
 	ShadeContext* const sc;
@@ -70,7 +72,7 @@ public:
 	}
 
 	void ResetOutput (int n) { sc->ResetOutput(n); }
-	Class_ID ClassID () { return sc->ClassID(); }
+	Class_ID ClassID () { return BERCON_SHADE_CONTEXT_CLASS_ID; }
 	BOOL InMtlEditor () { return sc->InMtlEditor(); }
 	int Antialias () { return sc->Antialias(); }
 	int ProjType () { return sc->ProjType(); }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -50,7 +50,7 @@ TilePoint Tile::corner(float rX, float rY, float w, float h, TileParam& t) {
 	// Evaluate	maps
 	if (t.tileRound) {
 		bool inCorner = false;
-		float cX, cY;
+		float cX=0.0f, cY=0.0f;
 		// Detect corner
 		if (rX < t.tileCrnrRad) { 
 			if (rY < t.tileCrnrRad) { // Bottom left


### PR DESCRIPTION
A crash happens when BerconGradient in random mode is assigned as a projector map to a spot light. In that case there is no node.
